### PR TITLE
[#166536717] Typo error in welcome message

### DIFF
--- a/WelcomeMessagesActivity/index.ts
+++ b/WelcomeMessagesActivity/index.ts
@@ -31,7 +31,7 @@ Scopri le funzioni e impara a usare l'app del cittadino.
 
 ### I messaggi
 IO ti consente di ricevere messaggi dalle Pubbliche Amministrazioni italiane, sia locali che nazionali, e all'occorrenza effettuare pagamenti.
-Puoi decidere da chi e come essere contattato, dalla sezione [servizi](ioit://PREFERENCES_SERVICES) di questa applicazione, e scegliere se inoltrare il messaggio anche al tuo indirizo email associato a SPID.
+Puoi decidere da chi e come essere contattato, dalla sezione [servizi](ioit://PREFERENCES_SERVICES) di questa applicazione, e scegliere se inoltrare il messaggio anche al tuo indirizzo email associato a SPID.
 
 ### I pagamenti
 


### PR DESCRIPTION
This PR fix the below typo error:

![image](https://user-images.githubusercontent.com/17931148/64614631-2eea9400-d3d9-11e9-9173-5e5d9cc28b93.png)
